### PR TITLE
Fixed webpack config for windows

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -611,7 +611,7 @@ function getLessonAliases() {
   const aliases = {}
   fs.readdirSync(lessonPath).forEach(file => {
     const name = path.basename(file, ".js")
-    aliases[path.join("app", name)] = path.join(lessonPath, file)
+    aliases[`app/${name}`] = path.join(lessonPath, file)
   })
 
   return aliases


### PR DESCRIPTION
Windows' local path separator is '\' instead of '/', which is what the node modules use. When indexing the alias, using path.join will make it (e.g.) 'app\LoginForm' on Windows only instead of the correct alias 'app/LoginForm'