### PR TITLE
Fixed onAuthStateChanged not returning unsubscribe

### DIFF
--- a/modules/app/utils.js
+++ b/modules/app/utils.js
@@ -41,7 +41,7 @@ export function logout() {
 }
 
 export function onAuthStateChanged(callback) {
-  auth().onAuthStateChanged(callback)
+  return auth().onAuthStateChanged(callback)
 }
 
 // logout()


### PR DESCRIPTION
This fixes the bug for Excercise 05 where returning the value from onAuthStateChanged doesn't actually unsubscribe it.