### PR TITLE
Use proper hook name in exercise 4 final snippet

### DIFF
--- a/lessons/04-effects/exercise/NewPost.final.js
+++ b/lessons/04-effects/exercise/NewPost.final.js
@@ -22,7 +22,7 @@ export default function NewPost({ takeFocus, date, showAvatar }) {
   const storageKey = makeNewPostKey(date)
 
   // Initialize the message for this date from the value in storage.
-  useLayoutEffect(() => {
+  useEffect(() => {
     setMessage(getLocalStorageValue(storageKey) || '')
   }, [storageKey])
 


### PR DESCRIPTION
I noticed the function being called does not use the proper hook name. Great content, thanks!