### PR TITLE
Fix for NaN `post.minutes`

### DIFF
--- a/modules/app/NewPost.js
+++ b/modules/app/NewPost.js
@@ -36,14 +36,17 @@ export default function NewPost({ takeFocus, date, onSuccess, showAvatar }) {
   const tooMuchText = message.length > MAX_MESSAGE_LENGTH
 
   const submit = event => {
+    // We specifically want to avoid refs for Minutes because it would
+    // require ref forwarding and not all Minutes components (lectures)
+    // will use ref forwarding (because they don't need it)
+    const minutesValue = parseInt(event.target.elements[3].value, 10)
+    const minutes = !Number.isNaN(minutesValue) ? minutesValue : 0
+
     setSaving(true)
     // eslint-disable-next-line
     createPost({
       message: messageRef.current.value,
-      // We specifically want to avoid refs for Minutes because it would
-      // require ref forwarding and not all Minutes components (lectures)
-      // will use ref forwarding (because they don't need it)
-      minutes: parseInt(event.target.elements[3].value, 10),
+      minutes,
       date: formatDate(date, DATE_FORMAT),
       uid: auth.uid
     }).then(post => {

--- a/modules/app/utils.js
+++ b/modules/app/utils.js
@@ -184,7 +184,9 @@ export function isValidDate(year, month, day) {
 }
 
 export function calculateTotalMinutes(posts) {
-  return posts.reduce((total, post) => post.minutes + total, 0)
+  return posts
+    .filter(post => !Number.isNaN(post.minutes))
+    .reduce((total, post) => post.minutes + total, 0)
 }
 
 export function calculateMakeup(total, expected, goal) {


### PR DESCRIPTION
For some reason NaN values were being stored to the DB. This PR prevents NaN values from being saved and filters out existing NaN values.

Reviewer: @ryanflorence 