### PR TITLE
Fix 'jumpy' Feed when click 'view more'

### DIFF
--- a/modules/app/App.css
+++ b/modules/app/App.css
@@ -14,6 +14,11 @@
   --green: hsl(170, 90%, 44%);
 }
 
+html {
+    width: 100vw;
+    overflow-x: hidden;
+}
+
 body {
   color: var(--gray);
 }


### PR DESCRIPTION
Every time you click on feed's, 'view more' button to get more posts, feed moves from not having scrollbar to have a scrollbar and consequently moves the page to the left.

I tried fixing with:

```css
html {margin-left: calc(100vw - 100%)}
```

it didn't work as you have a background image.

This one works fine, tested with Chrome & FF.